### PR TITLE
Compile PHP files from CLI

### DIFF
--- a/src/Compiler/CliCompiler.php
+++ b/src/Compiler/CliCompiler.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jderusse\Warmup\Compiler;
+
+final class CliCompiler implements CompilerInterface
+{
+    public function compile(string $file)
+    {
+        opcache_compile_file($file);
+    }
+}

--- a/src/Compiler/FallbackCompiler.php
+++ b/src/Compiler/FallbackCompiler.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Jderusse\Warmup\Compiler;
+
+final class FallbackCompiler implements CompilerInterface
+{
+    /** @var CompilerInterface[] */
+    private $compilers;
+
+    public function __construct(array $compilers)
+    {
+        $this->compilers = $compilers;
+    }
+
+    public function compile(string $file)
+    {
+        foreach ($this->compilers as $compiler) {
+            try {
+                return $compiler->compile($file);
+            } catch (\Throwable $e) {
+                continue;
+            }
+        }
+
+        throw new \RuntimeException("Failed to compile {$file}.");
+    }
+}

--- a/src/Console/WarmupCommand.php
+++ b/src/Console/WarmupCommand.php
@@ -6,6 +6,8 @@ use Composer\Command\BaseCommand;
 use Jderusse\Warmup\ClassmapReader\ChainReader;
 use Jderusse\Warmup\ClassmapReader\DirectoryReader;
 use Jderusse\Warmup\ClassmapReader\OptimizedReader;
+use Jderusse\Warmup\Compiler\CliCompiler;
+use Jderusse\Warmup\Compiler\FallbackCompiler;
 use Jderusse\Warmup\Compiler\PhpServerCompiler;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -60,7 +62,10 @@ class WarmupCommand extends BaseCommand
             )
         );
 
-        $compiler = new PhpServerCompiler();
+        $compiler = new FallbackCompiler([
+            new CliCompiler(),
+            new PhpServerCompiler(),
+        ]);
 
         foreach ($reader->getClassmap() as $file) {
             try {

--- a/src/Console/WarmupCommand.php
+++ b/src/Console/WarmupCommand.php
@@ -59,7 +59,9 @@ class WarmupCommand extends BaseCommand
                 )
             )
         );
+
         $compiler = new PhpServerCompiler();
+
         foreach ($reader->getClassmap() as $file) {
             try {
                 $compiler->compile($file);


### PR DESCRIPTION
The only compiler available as far as now was the PhpServerCompiler. I'm
not sure why, but it was taking way too much time on our current
project (> 1h).

I added a CliCompiler that just do the same as the former compiler, but
from the CLI. It now takes less than 5 seconds to compile ~5000 files.
Moreover, with this new compiler, we don't need the socket extension
anymore.

The default compiler is still PhpServerCompiler, but the CliCompiler can
be used by specifying --compiler option.