### PR TITLE
removed socket extension requirement

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,7 +6,6 @@ Optimize your application by warming up OpCode.
 
 - PHP `>=7.0`
 - Zend extension [Opcache](http://php.net/manual/en/book.opcache.php)
-- extension [Sockets](http://php.net/manual/en/book.sockets.php)
 - composer `>=1.0.0`
 
 ## Install

--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,7 @@
   "require": {
     "php": ">=7.0",
     "composer-plugin-api": "^1.0",
-    "ext-Zend-OPcache": "*",
-    "ext-sockets": "*"
+    "ext-Zend-OPcache": "*"
   },
   "extra": {
     "class": "Jderusse\\Warmup\\Plugin"


### PR DESCRIPTION
since the new fallback compiler was introduced in https://github.com/jderusse/composer-warmup/pull/10 the socket extension no longer is a hard requirement, right?

